### PR TITLE
added gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# sbt
+# (may want to keep parts of 'project')
+bin/
+project/
+target/
+build/
+
+# eclipse
+build
+.classpath
+.project
+.settings
+.worksheet
+
+# intellij idea
+*.log
+*.iml
+*.ipr
+*.iws
+.idea
+
+# mac
+.DS_Store
+
+# other?
+.history
+.scala_dependencies
+.cache
+.cache-main
+
+#general
+*.class


### PR DESCRIPTION
# Problem
We didn't have a `.gitignore` file so all of our IDE-generated artifacts were being tracked by git

# Solution
Add a .gitignore file to the project root

# Implementation details
I stole it from [Alvin Alexander ](https://alvinalexander.com/source-code/scala/sample-gitignore-file-scala-sbt-intellij-eclipse)