### PR TITLE
Tkt 1234 create goodbye endpoint

### DIFF
--- a/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
+++ b/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
@@ -34,6 +34,8 @@ object GittutorialRoutes {
   def goodbyeWorldRoutes[F[_]: Sync](G: GoodbyeWorld[F]): HttpRoutes[F] = {
     val dsl = new Http4sDsl[F]{}
     import dsl._
-    
+    HttpRoutes.of[F] {
+      
+    }
   }
 }

--- a/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
+++ b/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
@@ -35,7 +35,11 @@ object GittutorialRoutes {
     val dsl = new Http4sDsl[F]{}
     import dsl._
     HttpRoutes.of[F] {
-      
+      case GET -> Root / "goodbye" / name =>
+        for {
+          farewell <- G.goodbye(GoodbyeWorld.Name(name))
+          resp <- Ok(farewell)
+        } yield resp
     }
   }
 }

--- a/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
+++ b/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
@@ -30,4 +30,8 @@ object GittutorialRoutes {
         } yield resp
     }
   }
+
+  def goodbyeWorldRoutes[F[_]: Sync](G: GoodbyeWorld[F]): HttpRoutes[F] = {
+
+  }
 }

--- a/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
+++ b/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
@@ -32,6 +32,7 @@ object GittutorialRoutes {
   }
 
   def goodbyeWorldRoutes[F[_]: Sync](G: GoodbyeWorld[F]): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F]{}
 
   }
 }

--- a/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
+++ b/src/main/scala/com/github/gittutorial/GittutorialRoutes.scala
@@ -33,6 +33,7 @@ object GittutorialRoutes {
 
   def goodbyeWorldRoutes[F[_]: Sync](G: GoodbyeWorld[F]): HttpRoutes[F] = {
     val dsl = new Http4sDsl[F]{}
-
+    import dsl._
+    
   }
 }

--- a/src/main/scala/com/github/gittutorial/GittutorialServer.scala
+++ b/src/main/scala/com/github/gittutorial/GittutorialServer.scala
@@ -15,6 +15,7 @@ object GittutorialServer {
     for {
       client <- BlazeClientBuilder[F](global).stream
       helloWorldAlg = HelloWorld.impl[F]
+      goodbyeWorldAlg = GoodbyeWorld.impl[F]
       jokeAlg = Jokes.impl[F](client)
 
       // Combine Service Routes into an HttpApp.
@@ -23,8 +24,9 @@ object GittutorialServer {
       // in the underlying routes.
       httpApp = (
         GittutorialRoutes.helloWorldRoutes[F](helloWorldAlg) <+>
-        GittutorialRoutes.jokeRoutes[F](jokeAlg)
-      ).orNotFound
+          GittutorialRoutes.jokeRoutes[F](jokeAlg) <+>
+          GittutorialRoutes.goodbyeWorldRoutes[F](goodbyeWorldAlg)
+        ).orNotFound
 
       // With Middlewares in place
       finalHttpApp = Logger.httpApp(true, true)(httpApp)

--- a/src/main/scala/com/github/gittutorial/GoodbyeWorld.scala
+++ b/src/main/scala/com/github/gittutorial/GoodbyeWorld.scala
@@ -1,0 +1,37 @@
+package com.github.gittutorial
+
+import cats.Applicative
+import cats.implicits._
+import io.circe.{Encoder, Json}
+import org.http4s.EntityEncoder
+import org.http4s.circe._
+
+trait GoodbyeWorld[F[_]]{
+  def goodbye(n: GoodbyeWorld.Name): F[GoodbyeWorld.Farewell]
+}
+
+object GoodbyeWorld {
+  implicit def apply[F[_]](implicit ev: GoodbyeWorld[F]): GoodbyeWorld[F] = ev
+
+  final case class Name(name: String) extends AnyVal
+  /**
+    * More generally you will want to decouple your edge representations from
+    * your internal data structures, however this shows how you can
+    * create encoders for your data.
+    **/
+  final case class Farewell(farewell: String) extends AnyVal
+  object Farewell {
+    implicit val farewellEncoder: Encoder[Farewell] = new Encoder[Farewell] {
+      final def apply(a: Farewell): Json = Json.obj(
+        ("message", Json.fromString(a.farewell)),
+      )
+    }
+    implicit def farewellEntityEncoder[F[_]: Applicative]: EntityEncoder[F, Farewell] =
+      jsonEncoderOf[F, Farewell]
+  }
+
+  def impl[F[_]: Applicative]: GoodbyeWorld[F] = new GoodbyeWorld[F]{
+    def goodbye(n: GoodbyeWorld.Name): F[GoodbyeWorld.Farewell] =
+        Farewell("Goodbye, " + n.name).pure[F]
+  }
+}


### PR DESCRIPTION
# Problem
We work for the enterprise, the enterprise is very serious business. We can't abide by any humour. The joke endpoint must be disabled for our overlords to be pleased

# Solution
We can transform the `Jokes` endpoint into a `NoJokes` endpoint, so it will return a message telling the world how serious we are instead of a dad joke.

# Implementation details
* Changed the `Jokes` object to a `NoJokes` object
* `NoJokes` no longer does a GET request to get a joke, but just returns a message
* Updated the router so the joke route now points to `NoJokes`
* Updated the server with the new route